### PR TITLE
Justin feature/transcript rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 
       <button id="btnChoose">Choose Audio…</button>
       <button id="btnTranscribe" disabled>Transcribe</button>
+      <button id="btnDeleteSelection" disabled title="Delete selected words">Delete Selection</button>
 
       <div class="statusArea">
         <div id="status"></div>
@@ -107,12 +108,7 @@
 
       <!-- RIGHT COLUMN: Transcript only -->
       <section class="textPane">
-        <div style="display: flex; align-items: center; gap: 8px;">
-          <div class="paneTitle">Transcript</div>
-          <button id="btnRemoveSelected" disabled title="Remove selected words">
-            ✕ Remove
-          </button>
-        </div>
+        <div class="paneTitle">Transcript</div>
         <div id="transcript"></div>
       </section>
     </main>

--- a/style.css
+++ b/style.css
@@ -53,6 +53,27 @@ header {
 #status.error   { background: #fee2e2; color: #991b1b; }
 #status.success { background: #dcfce7; color: #166534; }
 
+/* Delete button styling */
+#btnDeleteSelection {
+  background: #fee2e2;
+  color: #991b1b;
+  border: 1px solid #fca5a5;
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+}
+
+#btnDeleteSelection:hover:not(:disabled) {
+  background: #fecaca;
+}
+
+#btnDeleteSelection:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ============================================================================
    Main Two-Pane Layout
    ========================================================================== */
@@ -247,26 +268,4 @@ main {
   color: #e8e8e8;
   font-size: 12px;
   line-height: 1.35;
-}
-
-/* Remove button styling */
-#btnRemoveSelected {
-  padding: 4px 8px;
-  font-size: 13px;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  background: #fff;
-  cursor: pointer;
-  white-space: nowrap;
-}
-
-#btnRemoveSelected:hover:not(:disabled) {
-  background: #fee2e2;
-  border-color: #991b1b;
-  color: #991b1b;
-}
-
-#btnRemoveSelected:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
 }


### PR DESCRIPTION
Description
Allows users to remove selected words from the transcript visually without modifying the audio file.

Changes
- Add "Delete Selection" button to header UI
- Implement `deleteSelectedWords()` function that mutates `words[]` array
- Clear selection, playhead, and detail view after deletion
- Re-render transcript DOM with remaining words
- Show status message with word deletion count

Type of Change
- Frontend UI/UX enhancement

Frontend-Only
- No audio file modifications
- No playback behavior changes
- No timestamp recalculation
- No undo/redo implementation
- No backend changes

Testing
1. Load audio file and transcribe
2. Click words to select single or range (Shift+click)
3. Click "Delete Selection" button
4. Verify:
   - Selected words removed from transcript
   - Selection and playhead cleared
   - Detail view hidden
   - Status message shows count of deleted words
5. Verify audio playback still works (though timings no longer align perfectly)


Closes #21 Implement UI-only transcript delete for selected word range #21
