### PR TITLE
feat: move pipeline spec to user-friendly Quality dropdown in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
       <button id="btnChoose">Choose Audio…</button>
       <button id="btnTranscribe" disabled>Transcribe</button>
 
+      <label for="modeSelect">Quality:</label>
+      <select id="modeSelect"></select>
+
       <div class="statusArea">
         <div id="status"></div>
         <progress id="transcribeProgress" value="0" max="100" hidden></progress>
@@ -77,17 +80,14 @@
           </summary>
 
           <div class="devBody">
-            <!-- Spec controls -->
+            <!-- Spec customization (selection moved to header) -->
             <div class="devSection">
               <div class="devSectionTitle">Transcription Pipeline</div>
 
               <div class="devRow">
-                <label for="specSelect">Spec:</label>
-                <select id="specSelect"></select>
-
                 <label class="checkbox">
                   <input type="checkbox" id="chkCustomSpec" />
-                  Customize
+                  Customize JSON
                 </label>
               </div>
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -690,7 +690,16 @@ otter.onTranscribeProgress((pct: number) => {
 //
 //==============================================================================
 
-const specSelect = mustGetEl<HTMLSelectElement>("specSelect");
+// Friendly display names for known spec files; unknown files fall back to their filename.
+const SPEC_FRIENDLY_LABELS: Record<string, string> = {
+  "fw.json":          "Quick",
+  "fw_cwt.json":      "Standard",
+  "fw_asw_cwt.json":  "Accurate",
+  "default_spec.json":"Best Quality",
+  "wx_asw_cwt.json":  "Best Quality (alt)",
+};
+
+const specSelect = mustGetEl<HTMLSelectElement>("modeSelect");
 const chkCustomSpec = mustGetEl<HTMLInputElement>("chkCustomSpec");
 const customSpecArea = mustGetEl<HTMLDivElement>("customSpecArea");
 const specJsonEl = mustGetEl<HTMLTextAreaElement>("specJson");
@@ -735,7 +744,7 @@ async function populateSpecSelect() {
   for (const f of files) {
     const opt = document.createElement("option");
     opt.value = f;
-    opt.textContent = f;
+    opt.textContent = SPEC_FRIENDLY_LABELS[f] ?? f;
     specSelect.appendChild(opt);
   }
 


### PR DESCRIPTION
Replaces the raw filename selector (default_spec.json, fw_cwt.json, etc.) in Developer Controls with a "Quality:" dropdown in the header showing user-friendly labels (Quick, Standard, Accurate, Best Quality). The Customize JSON editor remains in the Developer Controls panel.