### PR TITLE
Add Stop & Pause Transcript Button

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,9 @@
       <button id="btnChoose">Choose Audio…</button>
       <button id="btnTranscribe" disabled>Transcribe</button>
 
+      <label for="modeSelect">Quality:</label>
+      <select id="modeSelect"></select>
+
       <div class="statusArea">
         <div id="status"></div>
         <progress id="transcribeProgress" value="0" max="100" hidden></progress>
@@ -77,17 +80,14 @@
           </summary>
 
           <div class="devBody">
-            <!-- Spec controls -->
+            <!-- Spec customization (selection moved to header) -->
             <div class="devSection">
               <div class="devSectionTitle">Transcription Pipeline</div>
 
               <div class="devRow">
-                <label for="specSelect">Spec:</label>
-                <select id="specSelect"></select>
-
                 <label class="checkbox">
                   <input type="checkbox" id="chkCustomSpec" />
-                  Customize
+                  Customize JSON
                 </label>
               </div>
 

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
 
       <button id="btnChoose">Choose Audio…</button>
       <button id="btnTranscribe" disabled>Transcribe</button>
+      <button id="btnPause" hidden>⏸ Pause</button>
+      <button id="btnStop" hidden>⏹ Stop</button>
 
       <label for="modeSelect">Quality:</label>
       <select id="modeSelect"></select>

--- a/src/main.ts
+++ b/src/main.ts
@@ -264,11 +264,12 @@ ipcMain.handle(
   });
 
 ipcMain.handle("cancel-transcription", async () => {
-  // Send SIGTERM to the active process
-
+  // Send SIGKILL (not SIGTERM) so cancellation works even when the process
+  // is paused via SIGSTOP — a stopped process ignores SIGTERM.
   if (activeProcess) {
-    // childProcess.kill() returns true or false if the process was successfully killed
-    return activeProcess.kill("SIGTERM");
+    // Resume first if stopped, then kill
+    activeProcess.kill("SIGCONT");
+    return activeProcess.kill("SIGKILL");
   }
   return false;
 });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -73,6 +73,9 @@ type OtterApi = {
   listSpecFiles: () => Promise<string[]>;
   readSpecFile: (name: string) => Promise<string>;
   readDefaultSpec: () => Promise<string>;
+  pauseTranscription: () => Promise<boolean>;
+  resumeTranscription: () => Promise<boolean>;
+  cancelTranscription: () => Promise<boolean>;
 };
 
 declare global {
@@ -165,7 +168,21 @@ function mustGetEl<T extends HTMLElement>(id: string): T {
 const transcriptEl = mustGetEl<HTMLDivElement>("transcript");
 const btnChoose = mustGetEl<HTMLButtonElement>("btnChoose");
 const btnTranscribe = mustGetEl<HTMLButtonElement>("btnTranscribe");
+const btnPause = mustGetEl<HTMLButtonElement>("btnPause");
+const btnStop = mustGetEl<HTMLButtonElement>("btnStop");
 const statusEl = mustGetEl<HTMLDivElement>("status");
+
+let isPaused = false;
+
+function setTranscribingState(active: boolean) {
+  btnTranscribe.hidden = active;
+  btnPause.hidden = !active;
+  btnStop.hidden = !active;
+  if (!active) {
+    isPaused = false;
+    btnPause.textContent = "⏸ Pause";
+  }
+}
 
 function normalizeRange(a: number, b: number) {
   return a <= b ? { start: a, end: b } : { start: b, end: a };
@@ -607,9 +624,9 @@ btnTranscribe.addEventListener("click", async () => {
 
   try {
     btnChoose.disabled = true;
-    btnTranscribe.disabled = true;
     progressEl.value = 0;
     progressEl.hidden = false;
+    setTranscribingState(true);
 
     const result = await otter.transcribeAudio(audioPath, getActiveSpecArg());
     words = Array.isArray(result) ? result : (result.words || []);
@@ -619,13 +636,38 @@ btnTranscribe.addEventListener("click", async () => {
     renderTranscript(words);
   } catch (e: unknown) {
     const msg = e instanceof Error ? e.message : String(e);
-    setStatus("Transcription failed (see logs).", "error");
-    appendLog("\nERROR:\n" + msg + "\n");
+    if (msg.includes("cancelled")) {
+      setStatus("Transcription cancelled.", "info");
+    } else {
+      setStatus("Transcription failed (see logs).", "error");
+      appendLog("\nERROR:\n" + msg + "\n");
+    }
   } finally {
     btnChoose.disabled = false;
     btnTranscribe.disabled = false;
+    setTranscribingState(false);
     progressEl.hidden = true;
   }
+});
+
+// Handle the "Pause / Resume" button
+btnPause.addEventListener("click", async () => {
+  if (!isPaused) {
+    await otter.pauseTranscription();
+    isPaused = true;
+    btnPause.textContent = "▶ Resume";
+    setStatus("Transcription paused.", "info");
+  } else {
+    await otter.resumeTranscription();
+    isPaused = false;
+    btnPause.textContent = "⏸ Pause";
+    setStatus("Transcribing…", "working");
+  }
+});
+
+// Handle the "Stop" button
+btnStop.addEventListener("click", async () => {
+  await otter.cancelTranscription();
 });
 
 // Handle the "Choose File" button

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -690,7 +690,16 @@ otter.onTranscribeProgress((pct: number) => {
 //
 //==============================================================================
 
-const specSelect = mustGetEl<HTMLSelectElement>("specSelect");
+// Friendly display names for known spec files; unknown files fall back to their filename.
+const SPEC_FRIENDLY_LABELS: Record<string, string> = {
+  "fw.json":          "Quick",
+  "fw_cwt.json":      "Standard",
+  "fw_asw_cwt.json":  "Accurate",
+  "default_spec.json":"Best Quality",
+  "wx_asw_cwt.json":  "Best Quality (alt)",
+};
+
+const specSelect = mustGetEl<HTMLSelectElement>("modeSelect");
 const chkCustomSpec = mustGetEl<HTMLInputElement>("chkCustomSpec");
 const customSpecArea = mustGetEl<HTMLDivElement>("customSpecArea");
 const specJsonEl = mustGetEl<HTMLTextAreaElement>("specJson");
@@ -735,7 +744,7 @@ async function populateSpecSelect() {
   for (const f of files) {
     const opt = document.createElement("option");
     opt.value = f;
-    opt.textContent = f;
+    opt.textContent = SPEC_FRIENDLY_LABELS[f] ?? f;
     specSelect.appendChild(opt);
   }
 


### PR DESCRIPTION
When a transcription is in progress, the transcript button is replaced with a stop and pause button. When a transcription is stopped a user-friendly message appears stating the user stopped the transcription process. Fixed a bug where a transcript wouldn't stop if paused until unpaused, sends a `SIGTERM` instead of a `SIGKILL`.