### PR TITLE
Updated breakline feature

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -83,6 +83,7 @@ type PieceEntry = {
   word: string;
   sourceStart: number;
   sourceEnd: number;
+  breakAfter?: number;
 };
 
 type Piece = {
@@ -260,6 +261,7 @@ function buildPieceTableFromTranscript(
     word: w.word,
     sourceStart: w.start,
     sourceEnd: w.end,
+    breakAfter: w.breakAfter,
   }));
 
   return {
@@ -362,6 +364,14 @@ function performRedo(): boolean {
   undoStack.push(snapshotState(pieceTable));
   restoreSnapshot(pieceTable, redoStack.pop()!);
   return true;
+}
+
+function syncBreakAfterToPieceTable(): void {
+  if (!pieceTable) return;
+  const viewEntries = getViewEntries(pieceTable);
+  for (let i = 0; i < viewEntries.length && i < words.length; i++) {
+    viewEntries[i].entry.breakAfter = words[i].breakAfter;
+  }
 }
 
 function syncWordsFromPieceTable(): void {
@@ -2192,6 +2202,7 @@ btnSaveEdl.addEventListener("click", async () => {
   if (!pieceTable) return;
 
   try {
+    syncBreakAfterToPieceTable();
     const payload = { version: 2, pieceTable };
     const json = JSON.stringify(payload, null, 2);
     const savedPath = await otter.saveEdl(json);
@@ -2234,6 +2245,7 @@ btnLoadEdl.addEventListener("click", async () => {
       word: ve.entry.word,
       start: ve.entry.sourceStart,
       end: ve.entry.sourceEnd,
+      breakAfter: ve.entry.breakAfter,
     }));
 
     // Load the source audio waveform


### PR DESCRIPTION
- Added breakline feature to the transcript
- Users can press Enter to add line breaks after words
- Backspace removes breaklines before deleting words
- Ctrl + Z / Ctrl + Shift + Z works with breaklines (undo/redo)
- Breaklines now persist when saving the EDL
- Loading a saved EDL will restore all breaklines as they were before